### PR TITLE
Added License

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,13 @@
+Copyright 2012
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -4,3 +4,5 @@ udacityplus
 stylized **U+**
 
 The Udacity Collaborative Social Network
+
+http://udacityplus.appspot.com


### PR DESCRIPTION
All contributions to the UdacityPlus source are licensed under the Apache 2 license.
